### PR TITLE
kakao login API .ver1

### DIFF
--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -203,15 +203,6 @@ exports.getUserInfo = async function (req, res) {
  * [GET] /app/auth/kakao
  */
 
- exports.getUserIdx = async function (req, res) {
-  const userId = req.params.userId;
-
-  if(!userId) return res.send(errResponse(baseResponse.SIGNUP_USERID_EMPTY));
-
-  const userIdxResponse = await userProvider.getUserIdx(userId);
-  return res.send(userIdxResponse);
-}
-
 passport.use(
   "kakao-login",
   new KakaoStrategy(

--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -6,6 +6,17 @@ const { response, errResponse } = require("../../../config/response");
 const logger = require("../../../config/winston");
 const crypto = require("crypto");
 const regexEmail = require("regex-email");
+
+const passport = require("passport");
+const KakaoStrategy = require("passport-kakao").Strategy;
+const axios = require("axios");
+
+const kakao = {
+  clientID: '3a65349851f0c41d0c6038609b178594',
+  //clientSecret: 'PwWQHM1dV1cdRLtyyGwmKlu3c3rrRTBv',
+  redirectUri: 'http://127.0.0.1:3001/auth/kakao/callback'
+}
+
 //controller : 판단 부분.
 /**
  * API No. 1
@@ -185,3 +196,86 @@ exports.getUserInfo = async function (req, res) {
   
   return res.send(userMypageResponse);
 }
+
+/**
+ * API No. 7
+ * API Name : 카카오 로그인 API
+ * [GET] /app/auth/kakao
+ */
+
+ exports.getUserIdx = async function (req, res) {
+  const userId = req.params.userId;
+
+  if(!userId) return res.send(errResponse(baseResponse.SIGNUP_USERID_EMPTY));
+
+  const userIdxResponse = await userProvider.getUserIdx(userId);
+  return res.send(userIdxResponse);
+}
+
+passport.use(
+  "kakao-login",
+  new KakaoStrategy(
+    {
+      clientID: kakao.clientID,
+      //clientSecret: kakao.clientSecret,
+      callbackURL: kakao.redirectUri,
+    },
+    async (accessToken, refreshToken, profile, done) => {
+      console.log(accessToken);
+      console.log("-------------------------------------------------------");
+      console.log(refreshToken);
+      console.log("-------------------------------------------------------");
+      console.log(profile);
+      console.log("-------------------------------------------------------");
+      console.log(done);
+      
+      kakaoProfile = await axios.get("https://kapi.kakao.com/v2/user/me", {
+        headers: {
+          Authorization: "Bearer " + accessToken,
+          "Content-Type": "application/json",
+        },
+      });
+
+      console.log(kakaoProfile.data.kakao_account);
+      // 여기까지 카카오 자체 로그인은 성공. 이제 우리 APP에 로그인이 가능한 지 체크.
+
+      const token = await jwt.sign(
+        {
+          userId: userIdx[0].id,
+        }, // 토큰의 내용(payload)
+        secret_config.jwtsecret, // 비밀키
+        {
+          expiresIn: "365d",
+          subject: "userInfo",
+        } // 유효 기간 365일
+      );
+      //client와 로그인 유지를 위한 서버의 토큰 발행.
+
+      let {nickname,email} = kakaoProfile.data.kakao_account.profile;
+      var nickName = nickname;
+      console.log(`해당 계정의 닉네임은 ${nickName}입니다`);
+      
+      if(!email){
+        console.log("카카오 계정의 이메일을 불러올 수 없습니다.");
+        return done(null, false, { message: '이메일 정보가 없어서 로그인에 실패하였습니다.' });
+      }
+      
+      else {
+        console.log(`해당 계정의 이메일은 ${email}입니다`);
+
+        const checkEmailExist = await userProvider.emailCheck(email); // 기존 유저 확인 by Email
+    
+        if(checkEmailExist === 1) {
+          //const userId = await userProvider.getUserIdByEmail(email); // 유저 아이디 획득 by Email
+          //const loginData = {token, userId};
+
+          console.log("카카오 계정으로 등록된 유저 정보가 DB에 있습니다")
+          return done(null, token, { message: '로그인에 성공하였습니다.' }); } 
+
+        else {
+          console.log("카카오 계정으로 등록된 유저 정보가 DB에 없습니다. 로그인 불가합니다.")
+          return done(null, false, { message: '회원가입이 가능합니다.' });
+        }
+      }
+    }) 
+);

--- a/src/app/User/userRoute.js
+++ b/src/app/User/userRoute.js
@@ -21,6 +21,10 @@ module.exports = function (app) {
     // 6. 유저 프로필 조회 (마이페이지) API
     app.get("/user/mypage/:userIdx", user.getUserProfile);
 
+    // 7. 카카오 로그인 API
+    app.get('/auth/kakao', passport.authenticate('kakao-login')); 
+    app.get('/auth/kakao/callback', passport.authenticate('kakao-login', { failureRedirect: '/user/login', successRedirect: '/home' }));
+
     // 3. 회원 프로필 조회 API
     //app.get("/user/:selectedId/profile", jwtMiddleware, user.getUserProfile);
 


### PR DESCRIPTION
# kakao login API - localhost test 완료
* 로컬에서만 테스트를 진행보았습니다. -> 추후 코뿡과 안드로이드 테스트 진행.
* 초기에 로그인이 진행되면 그 다음부턴 개인정보 동의 화면이 뜨지 않기 때문에 동의 화면에 대한 테스트는 여러 계정으로 진행해야될 것 같습니다.
### 카카오 계정의 email을 받지 못한 상황
- 우리 APP의 기존 유저인지 판단할 수 없어서 로그인 거절 -> 로그인 URL으로 redirect
### 카카오 계정의 email을 받은 상황
- 카카오 계정의 email과 동일한 이메일이 우리 User DB에 존재 -> 로그인 승인 -> jwt 발행해서 client에 전달 & home 화면 URL으로 redirect.
- 우리 DB 에 존재하지 X -> 로그인 거절 -> 로그인 URL으로 redirect