### PR TITLE
change http method of signaling api.14

### DIFF
--- a/src/app/Signal/signalRoute.js
+++ b/src/app/Signal/signalRoute.js
@@ -44,5 +44,5 @@ module.exports = function (app) {
     app.get("/mysignal", jwtMiddleware, signal.getMySignal);
 
     // 해당 닉네임의 유저 정보 조회 14
-    app.get("/signal/info", signal.getInfoFromNickName);
+    app.post("/signal/info", signal.getInfoFromNickName);
 };


### PR DESCRIPTION
get 메서드로 body에 데이터를 보내는 방법이 저희 클라이언트 에서는 동작하지 않는거 같아서 get 대신 post 메서드를 사용하도록 변경했습니다.